### PR TITLE
Port the demote command to v2

### DIFF
--- a/lib/esm/command/territory/add.rb
+++ b/lib/esm/command/territory/add.rb
@@ -51,7 +51,7 @@ module ESM
         end
 
         def on_request_accepted
-          call_sqf_function("ESMs_command_add", territory: arguments.territory_id)
+          call_sqf_function("ESMs_command_add", territory_id: arguments.territory_id)
           on_response
         end
 

--- a/lib/esm/command/territory/demote.rb
+++ b/lib/esm/command/territory/demote.rb
@@ -31,15 +31,11 @@ module ESM
           # Check for registered target_user. A steam_uid is valid here so don't check ESM::User::Ephemeral
           check_for_registered_target_user! if target_user.is_a?(ESM::User)
 
-          deliver!(
-            function_name: "demotePlayer",
-            territory_id: arguments.territory_id,
-            target_uid: target_uid,
-            uid: current_user.steam_uid
+          call_sqf_function(
+            "ESMs_command_demote",
+            territory_id: arguments.territory_id
           )
-        end
 
-        def on_response
           message = I18n.t(
             "commands.demote.success_message",
             user: current_user.mention,
@@ -49,6 +45,32 @@ module ESM
           )
 
           reply(ESM::Embed.build(:success, description: message))
+        end
+
+        module V1
+          def on_execute
+            # Check for registered target_user. A steam_uid is valid here so don't check ESM::User::Ephemeral
+            check_for_registered_target_user! if target_user.is_a?(ESM::User)
+
+            deliver!(
+              function_name: "demotePlayer",
+              territory_id: arguments.territory_id,
+              target_uid: target_uid,
+              uid: current_user.steam_uid
+            )
+          end
+
+          def on_response
+            message = I18n.t(
+              "commands.demote.success_message",
+              user: current_user.mention,
+              target_uid: target_uid,
+              territory_id: arguments.territory_id,
+              server: target_server.server_id
+            )
+
+            reply(ESM::Embed.build(:success, description: message))
+          end
         end
       end
     end

--- a/lib/esm/connection/client/lifecycle.rb
+++ b/lib/esm/connection/client/lifecycle.rb
@@ -62,9 +62,9 @@ module ESM
         end
 
         def authenticate!(model)
-          @public_id = +model.public_id
+          @public_id = model.public_id
+          secret_key = model.server_key
 
-          secret_key = +model.server_key
           @encryption = Encryption.new(secret_key)
 
           # Generate new nonce indices for the client

--- a/lib/esm/message.rb
+++ b/lib/esm/message.rb
@@ -94,9 +94,11 @@ module ESM
     #     message   # Treats the message like a string and sends it as is
     #   content [String] The content of this error.
     def add_errors(errors = [])
-      return if !errors.respond_to?(:each)
+      errors.each do |error|
+        error = error.symbolize_keys
+        add_error(error[:type].to_s, error[:content])
+      end
 
-      errors.each { |error| add_error(error[:type].to_s, error[:content]) }
       self
     end
 

--- a/spec/@esm/esms_system_territory_check_access_spec.rb
+++ b/spec/@esm/esms_system_territory_check_access_spec.rb
@@ -67,15 +67,16 @@ describe "ESMs_system_territory_checkAccess", :requires_connection, v2: true do
     end
   end
 
-  context "when the player does not have high enough permissions"
-  it "returns false" do
-    response = execute_sqf!(
-      <<~SQF
-        private _territory = #{territory.id} call ESMs_system_territory_get;
-        [#{user.steam_uid.quoted}, _territory, "owner"] call ESMs_system_territory_checkAccess
-      SQF
-    )
+  context "when the player does not have high enough permissions" do
+    it "returns false" do
+      response = execute_sqf!(
+        <<~SQF
+          private _territory = #{territory.id} call ESMs_system_territory_get;
+          [#{user.steam_uid.quoted}, _territory, "owner"] call ESMs_system_territory_checkAccess
+        SQF
+      )
 
-    expect(response).to be(false)
+      expect(response).to be(false)
+    end
   end
 end

--- a/spec/@esm/esms_system_territory_check_access_spec.rb
+++ b/spec/@esm/esms_system_territory_check_access_spec.rb
@@ -15,7 +15,7 @@ describe "ESMs_system_territory_checkAccess", :requires_connection, v2: true do
   end
 
   before do
-    user.create_account
+    user.exile_account
     territory.create_flag
   end
 

--- a/spec/@esm/esms_system_territory_get_spec.rb
+++ b/spec/@esm/esms_system_territory_get_spec.rb
@@ -15,7 +15,7 @@ describe "ESMs_system_territory_get", :requires_connection, v2: true do
   end
 
   before do
-    user.create_account
+    user.exile_account
   end
 
   context "when the territory exists" do

--- a/spec/@esm/territory_id_decoding_spec.rb
+++ b/spec/@esm/territory_id_decoding_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe "Territory ID decoding", :requires_connection do
+  include_context "connection"
+
+  let!(:territory) do
+    owner_uid = ESM::Test.steam_uid
+    create(
+      :exile_territory,
+      owner_uid: owner_uid,
+      moderators: [owner_uid],
+      build_rights: [owner_uid],
+      server_id: server.id
+    )
+  end
+
+  before do
+    # Create a dummy function to call
+    execute_sqf! <<~SQF
+      missionNamespace setVariable [
+        "MyDummyFunction",
+        {
+          [[(_this get "id")]] call ESMs_util_command_handleSuccess;
+        }
+      ];
+    SQF
+  end
+
+  after do
+    # And cleanup the function
+    execute_sqf!("missionNamespace setVariable ['MyDummyFunction', nil];")
+  end
+
+  context "when the value is a valid encoded territory ID" do
+    it "decodes it and completes the request" do
+      message = ESM::Message.new.set_type(:call)
+        .set_data(
+          function_name: "MyDummyFunction",
+          territory_id: territory.encoded_id
+        )
+
+      expect { server.send_message(message) }.not_to raise_error
+    end
+  end
+
+  context "when the value is a valid custom territory ID" do
+    before do
+      territory.update!(esm_custom_id: "my_custom_id")
+    end
+
+    it "decodes it and completes the request" do
+      message = ESM::Message.new.set_type(:call)
+        .set_data(
+          function_name: "MyDummyFunction",
+          territory_id: territory.esm_custom_id
+        )
+
+      expect { server.send_message(message) }.not_to raise_error
+    end
+  end
+
+  context "when the value is not a valid encoded territory ID" do
+    it "fails to decode" do
+      message = ESM::Message.new.set_type(:call)
+        .set_data(territory_id: "gibberish") # function is not needed for this test
+
+      expectation = expect { server.send_message(message) }
+      expectation.to raise_error(ESM::Exception::ExtensionError) do |error|
+        expect(error.data.description).to match("I was unable to find an active territory")
+      end
+    end
+  end
+end

--- a/spec/esm/command/server/me_spec.rb
+++ b/spec/esm/command/server/me_spec.rb
@@ -46,8 +46,8 @@ describe ESM::Command::Server::Me, category: "command" do
       include_context "connection"
 
       before do
-        user.create_account
-        user.create_player
+        user.exile_account
+        user.exile_player
       end
 
       context "when the user has an account on the server" do

--- a/spec/esm/command/server/sqf_spec.rb
+++ b/spec/esm/command/server/sqf_spec.rb
@@ -158,7 +158,7 @@ describe ESM::Command::Server::Sqf, category: "command" do
 
       before do
         grant_command_access!(community, "sqf")
-        user.create_account
+        user.exile_account
       end
 
       context "when the code is executed on the server and the code returns a result" do

--- a/spec/esm/command/territory/add_spec.rb
+++ b/spec/esm/command/territory/add_spec.rb
@@ -142,8 +142,8 @@ describe ESM::Command::Territory::Add, category: "command" do
       end
 
       before do
-        user.create_account
-        second_user.create_account
+        user.exile_account
+        second_user.exile_account
 
         territory.create_flag
       end

--- a/spec/esm/command/territory/demote_spec.rb
+++ b/spec/esm/command/territory/demote_spec.rb
@@ -218,9 +218,7 @@ describe ESM::Command::Territory::Demote, category: "command" do
 
       context "when the player is not a moderator" do
         before do
-          territory.moderators.delete(user.steam_uid)
-          territory.build_rights.delete(user.steam_uid)
-          territory.save!
+          territory.revoke_membership(user.steam_uid)
         end
 
         it "raises Demote_MissingAccess and Demote_MissingAccess_Admin" do
@@ -294,9 +292,7 @@ describe ESM::Command::Territory::Demote, category: "command" do
 
       context "when the target is not a member" do
         before do
-          territory.moderators.delete(second_user.steam_uid)
-          territory.build_rights.delete(second_user.steam_uid)
-          territory.save!
+          territory.revoke_membership(second_user.steam_uid)
         end
 
         it "raises Demote_CannotDemoteNothing" do

--- a/spec/support/extensions/esm/model/exile_account.rb
+++ b/spec/support/extensions/esm/model/exile_account.rb
@@ -16,6 +16,11 @@ module ESM
     attribute :last_disconnect_at, :datetime
     attribute :total_connections, :integer, default: 1
 
+    has_one :player,
+      class_name: "ESM::ExilePlayer",
+      foreign_key: "account_uid",
+      dependent: :destroy
+
     def self.from(user)
       where(uid: user.steam_uid).first_or_create do |account|
         account.name = user.discord_username

--- a/spec/support/extensions/esm/model/exile_player.rb
+++ b/spec/support/extensions/esm/model/exile_player.rb
@@ -48,6 +48,8 @@ module ESM
     attribute :vest_weapons, :json, default: []
     attribute :last_updated_at, :datetime, default: -> { Time.current }
 
+    belongs_to :account, class_name: "ESM::ExileAccount", inverse_of: :player
+
     def self.from(user)
       model =
         where(account_uid: user.steam_uid).first_or_initialize.tap do |player|

--- a/spec/support/extensions/esm/model/exile_territory.rb
+++ b/spec/support/extensions/esm/model/exile_territory.rb
@@ -138,8 +138,9 @@ module ESM
     # _flagObject setVariable ["ExileRadiusShown", false, true];
     # _flagObject setVariable ["ExileFlagStolen",_flagStolen,true];
     # _flagObject setVariable ["ExileFlagTexture",_flagTexture];
+    IGNORED_ATTRIBUTES = %w[server_id esm_custom_id]
     def update_arma
-      changed_items = previous_changes.except("server_id")
+      changed_items = previous_changes.except(*IGNORED_ATTRIBUTES)
       return if changed_items.blank? || changed_items.key?("id")
 
       sqf = "private _flagObject = #{id} call ESMs_system_territory_get;"


### PR DESCRIPTION
I did a bit more work that expected... I should start expecting that lol. 

Changelog:
- Ported demote command to v2
- I moved away from "territory" argument to the territory_id argument instead. 
- I also fixed a bug with send_request. Instead of using the incoming message to translate the errors, it now uses the original outgoing message. 
- Added specs for automatic territory ID decoding 
- Renamed some spec methods 
- Updated `ESMs_command_add` to check for target account existence. Adjusted check for existing builders